### PR TITLE
Add setting to scale combat tracker UI

### DIFF
--- a/css/monks-common-display.css
+++ b/css/monks-common-display.css
@@ -1,3 +1,7 @@
+:root {
+    --combat-popout-scale: 1;
+}
+
 body.hide-ui > *:not(#logo):not(#board):not(#hud):not(#ui-left):not(#ui-middle):not(#ui-right):not(#confetti-canvas):not(#dice-box-canvas):not(#pause):not(#notifications):not(#narrator):not(#combat-popout):not(.image-popout):not(.journal-sheet):not(.journal-attached):not(#slideshow-display):not(#slideshow-canvas):not(#combat-carousel),
 body.hide-ui #ui-left > *,
 body.hide-ui #ui-middle > *:not(#loading),
@@ -21,6 +25,8 @@ body.hide-ui #combat-popout {
     left: 0px !important;
     height: 70px !important;
     min-height: 70px !important;
+    transform-origin: top left;
+    transform: scale(var(--combat-popout-scale));
 }
 body.hide-ui.show-combatants #combat-popout {
     height: unset !important;

--- a/lang/en.json
+++ b/lang/en.json
@@ -16,6 +16,8 @@
   "MonksCommonDisplay.show-combatants.name": "Show all combatants",
   "MonksCommonDisplay.show-combatants.hint": "Instead of just show the active combatant, show the entire list",
   "MonksCommonDisplay.limit-shown.name": "Limit shown combatants",
+  "MonksCommonDisplay.combat-scale.name": "Combat Scale",
+  "MonksCommonDisplay.combat-scale.hint": "Scale the size of the combat UI smaller or larger",
 
   "MonksCommonDisplay.change-settings": "Change Settings",
   "MonksCommonDisplay.mirror-screen": "Mirror Screen",

--- a/monks-common-display.js
+++ b/monks-common-display.js
@@ -105,6 +105,7 @@ export class MonksCommonDisplay {
             .attr('limit-combatants', setting('limit-shown'));
         if (display && ui.sidebar)
             ui.sidebar.activateTab('chat');
+        $("body").get(0).style.setProperty("--combat-popout-scale", display ? setting('combat-scale') : 1);
 
         //$('#sidebar').toggle(setting('show-chat-log') || !display);
     }

--- a/settings.js
+++ b/settings.js
@@ -110,6 +110,23 @@ export const registerSettings = function () {
 		}
 	});
 
+	game.settings.register(modulename, "combat-scale", {
+		name: i18n("MonksCommonDisplay.combat-scale.name"),
+		hint: i18n("MonksCommonDisplay.combat-scale.hint"),
+		scope: "world",
+		config: true,
+		range: {
+			min: 0.1,
+			max: 5,
+			step: 0.1,
+		},
+		default: 1,
+		type: Number,
+		onChange: () => {
+			MonksCommonDisplay.toggleCommonDisplay();
+		}
+	});
+
 	game.settings.register(modulename, "startupdata", {
 		name: '',
 		hint: '',


### PR DESCRIPTION
Closes #16.

I took a stab at adding a setting to make to the combat tracker UI larger (or smaller). I went with a basic scale transform for simplicity, driven by a CSS variable tied to the setting value.