### PR TITLE
Added module exceptions for Bossbar and Epic Rolls

### DIFF
--- a/css/monks-common-display.css
+++ b/css/monks-common-display.css
@@ -3,7 +3,7 @@
 }
     */
 
-body.hide-ui > *:not(#logo):not(#interface):not(#board):not(#hud):not(#ui-left):not(#ui-middle):not(#ui-right):not(#confetti-canvas):not(#dice-box-canvas):not(#pause):not(#notifications):not(#narrator):not(#combat-popout):not(.image-popout):not(.journal-sheet):not(.journal-attached):not(#slideshow-display):not(#slideshow-canvas):not(#combat-carousel):not(#levels3d):not(#av-config):not(#camera-views):not(#combat-dock):not(#conversation-hud-background):not(.story-sheet),
+body.hide-ui > *:not(#logo):not(#interface):not(#board):not(#hud):not(#ui-left):not(#ui-middle):not(#ui-right):not(#confetti-canvas):not(#dice-box-canvas):not(#pause):not(#notifications):not(#narrator):not(#combat-popout):not(.image-popout):not(.journal-sheet):not(.journal-attached):not(#slideshow-display):not(#slideshow-canvas):not(#combat-carousel):not(#levels3d):not(#av-config):not(#camera-views):not(#combat-dock):not(#conversation-hud-background):not(.story-sheet):not(#boss-bar):not(#epic-roll-5e),
 body.hide-ui #ui-left > *:not(#smalltime-app),
 body.hide-ui #ui-middle > *:not(#ui-top):not(#ui-bottom):not(#ui-conversation-hud),
 body.hide-ui #ui-middle #ui-top > *:not(#loading):not(#combat-dock):not(.bossBar):not(.bossBarSpacer),


### PR DESCRIPTION
Existing exclusion for boss-bar doesn't seem to capture the elements used anymore, as boss-bar is a direct child of body.