### PR TITLE
Avoid panning to hidden (hidden in combat tracker) combatant

### DIFF
--- a/monks-common-display.js
+++ b/monks-common-display.js
@@ -547,7 +547,7 @@ export class MonksCommonDisplay {
     }
 
     static getTokens(value) {
-        if (value == "combat" && game.combats.active && game.combats.active.started && game.combats.active.combatant?.token && !game.combats.active.combatant?.token.hidden) {
+        if (value == "combat" && game.combats.active && game.combats.active.started && game.combats.active.combatant?.token && !game.combats.active.combatant.hidden && !game.combats.active.combatant?.token.hidden) {
             let targets = Array.from(game.user.targets).map(t => t.document);
             return [game.combats.active.combatant?.token, ...targets];
         }

--- a/monks-common-display.js
+++ b/monks-common-display.js
@@ -238,7 +238,7 @@ export class MonksCommonDisplay {
 
         if (game.user.isGM) {
             MonksCommonDisplay.initGM();
-        } 
+        }
         game.socket.on(MonksCommonDisplay.SOCKET, MonksCommonDisplay.onMessage);
 
         if (display && game.combats.active) {
@@ -731,7 +731,7 @@ Hooks.on("controlToken", async (token, control) => {
     if (display && setting("focus-toggle")) {
         // double-check that this is the token that should be focussed
         let shouldControl = (focus == "gm" && MonksCommonDisplay.gmControlledTokens.has(token.id)) ||
-            (focus == "combat" && game.combats.active && game.combats.active.combatant?.token.id == token.id) || 
+            (focus == "combat" && game.combats.active && game.combats.active.combatant?.token.id == token.id) ||
             (focus == token.id || focus == token.actor?.id);
         if (control != shouldControl) {
             if (shouldControl)


### PR DESCRIPTION
If the DM moves combatants outside the visual range and do not want to display these enemies on the player's combat tracker (or carousel) the DM would 'hide' them in the combat tracker. Currently, Common Display moves the camera to these NPCs. With this PR I provide one more condition to filter out specifically theses actors