### PR TITLE
Make sure combat tab does not pop out when Show combat setting is unticked

### DIFF
--- a/monks-common-display.js
+++ b/monks-common-display.js
@@ -247,7 +247,7 @@ export class MonksCommonDisplay {
         } 
         game.socket.on(MonksCommonDisplay.SOCKET, MonksCommonDisplay.onMessage);
 
-        if (display && game.combats.active) {
+        if (display && setting("show-combat") && game.combats.active) {
             ui.combat.renderPopout(ui.combat);
             window.setTimeout(function () {
                 MonksCommonDisplay.setScrollTop();


### PR DESCRIPTION
Currently the combat tab pops out for the common user even if the Show combat setting is disabled:
<img width="774" height="489" alt="image" src="https://github.com/user-attachments/assets/f658a9e5-3171-4b4f-9268-44408efb9ed7" />
This pull request makes the setting be fully respected. 
